### PR TITLE
Added Mac ARM 64-bit Build Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bom*
 
 # IDE file
 .swp
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,25 @@ generate: mod
 
 .PHONY: build
 build: mod
-	@echo "Building spdx-sbom-generator version:$(VERSION)"
+	@echo "Building spdx-sbom-generator for Linux Intel/AMD 64-bit version:$(VERSION)"
 	@GO111MODULE=on GOFLAGS=-mod=vendor GOOS=linux go build -o bin/spdx-sbom-generator cmd/generator/generator.go
 	@chmod +x bin/spdx-sbom-generator
 
 .PHONY: build-mac
 build-mac: mod
-	@echo "Building spdx-sbom-generator version:$(VERSION)"
+	@echo "Building spdx-sbom-generator for Mac Intel/AMD 64-bit version:$(VERSION)"
 	@GO111MODULE=on GOFLAGS=-mod=vendor GOOS=darwin GOARCH=amd64 go build -o bin/spdx-sbom-generator cmd/generator/generator.go
+	@chmod +x bin/spdx-sbom-generator
+
+.PHONY: build-mac-arm64
+build-mac-arm64: mod
+	@echo "Building spdx-sbom-generator for Mac ARM 64-bit version:$(VERSION)"
+	@GO111MODULE=on GOFLAGS=-mod=vendor GOOS=darwin GOARCH=arm64 go build -o bin/spdx-sbom-generator cmd/generator/generator.go
 	@chmod +x bin/spdx-sbom-generator
 
 .PHONY: build-win
 build-win: mod
-	@echo "Building spdx-sbom-generator version:$(VERSION)"
+	@echo "Building spdx-sbom-generator for Windows Intel/AMD 64-bit version:$(VERSION)"
 	@GO111MODULE=on GOFLAGS=-mod=vendor GOOS=win GOARCH=amd64 go build -o bin/spdx-sbom-generator.exe cmd/generator/generator.go
 	@chmod +x bin/spdx-sbom-generator.exe
 

--- a/README.md
+++ b/README.md
@@ -429,17 +429,22 @@ you can provide the CLI parameters that will be passed along the comamnd, e.g.:
 ARGS="--path /home/ubuntu/projects/expressjs" make generate
 ```
 
-* Build linux binary
+* Build linux Intel/AMD 64-bit binary
 ```BASH
 make build
 ```
 
-* Build Mac binary
+* Build Mac Intel/AMD 64-bit binary
 ```BASH
 make build-mac
 ```
 
-* Build Windows binary
+* Build Mac ARM 64-bit binary
+```BASH
+make build-mac-arm64
+```
+
+* Build Windows Intel/AMD 64-bit binary
 ```BASH
 make build-win
 ```


### PR DESCRIPTION
- Added build-mac-arm64 makefile target for generating the binary
- Updated build docs to include mac ARM 64-bit build support
- Added ignore file entry for Jetbrains/IntelliJ IDE config files

Signed-off-by: David Deal <dealako@gmail.com>