### PR TITLE
Updates to license and version data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ build-mac-arm64: mod
 .PHONY: build-win
 build-win: mod
 	@echo "Building spdx-sbom-generator for Windows Intel/AMD 64-bit version:$(VERSION)"
-	@GO111MODULE=on GOFLAGS=-mod=vendor GOOS=win GOARCH=amd64 go build -ldflags $(ldflags) -o bin/spdx-sbom-generator.exe cmd/generator/generator.go
+	@GO111MODULE=on GOFLAGS=-mod=vendor GOOS=windows GOARCH=amd64 go build -ldflags $(ldflags) -o bin/spdx-sbom-generator.exe cmd/generator/generator.go
 	@chmod +x bin/spdx-sbom-generator.exe
 
 $(LINT_TOOL):

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/go-enry/go-license-detector/v4 v4.2.0
+	github.com/go-git/go-git/v5 v5.1.0
 	github.com/google/uuid v1.2.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -112,7 +112,10 @@ func (f *Format) Render() error {
 func generatePackage(file *os.File, pkg models.Package) {
 	file.WriteString(fmt.Sprintf("PackageName: %s\n", pkg.PackageName))
 	file.WriteString(fmt.Sprintf("SPDXID: %s\n", pkg.SPDXID))
-	file.WriteString(fmt.Sprintf("PackageVersion: %s\n", pkg.PackageVersion))
+	if pkg.PackageVersion != "" {
+		file.WriteString(fmt.Sprintf("PackageVersion: %s\n", pkg.PackageVersion))
+	}
+
 	file.WriteString(fmt.Sprintf("PackageSupplier: %s\n", pkg.PackageSupplier))
 	file.WriteString(fmt.Sprintf("PackageDownloadLocation: %s\n", pkg.PackageDownloadLocation))
 	file.WriteString(fmt.Sprintf("FilesAnalyzed: %v\n", pkg.FilesAnalyzed))
@@ -181,9 +184,9 @@ func (f *Format) convertToPackage(module models.Module) (models.Package, error) 
 		FilesAnalyzed:           false,
 		PackageChecksum:         module.CheckSum.String(),
 		PackageHomePage:         buildHomepageURL(module.PackageURL),
-		PackageLicenseConcluded: setPkgValue(module.LicenseConcluded),
-		PackageLicenseDeclared:  setPkgValue(module.LicenseDeclared),
-		PackageCopyrightText:    setPkgValue(module.Copyright),
+		PackageLicenseConcluded: noAssertion, // setPkgValue(module.LicenseConcluded),
+		PackageLicenseDeclared:  noAssertion, // setPkgValue(module.LicenseDeclared),
+		PackageCopyrightText:    noAssertion, // setPkgValue(module.Copyright),
 		PackageLicenseComments:  setPkgValue(""),
 		PackageComment:          setPkgValue(""),
 		RootPackage:             module.Root,
@@ -225,17 +228,21 @@ func buildVersion(module models.Module) string {
 	if module.Version != "" {
 		return module.Version
 	}
+
 	if !module.Root {
 		return module.Version
 	}
+
 	localGit, err := git.PlainOpen(module.LocalPath)
 	if err != nil {
 		return ""
 	}
+
 	head, err := localGit.Head()
 	if err != nil {
 		return ""
 	}
+
 	return head.Hash().String()[0:7]
 }
 


### PR DESCRIPTION
## Details
- Adds default version to root package if project is git based, it uses git hash short version
- Sets License data to `NOASSERTION` until we figure out a better tool to detect package licenses
- If package version is empty, then we don't print SPDX `PackageVersion`
- Fixes windows GO env on Makefile