### PR TITLE
Minor fix to skip if Home page already has scheme protocol

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	noAssertion = "NOASSERTION"
+	httpPrefix  = "http"
 )
 
 var replacer *strings.Replacer
@@ -221,6 +222,11 @@ func buildHomepageURL(url string) string {
 	if url == "" {
 		return noAssertion
 	}
+
+	if strings.HasPrefix(url, httpPrefix) {
+		return url
+	}
+
 	return fmt.Sprintf("https://%s", url)
 }
 


### PR DESCRIPTION
## ISSUE: https://github.com/spdx/spdx-sbom-generator/issues/136

## Details
- If package home page already has scheme protocol provided by the plugin return it as it is