### PR TITLE
Optimize the spdx generation time for pip

### DIFF
--- a/internal/modules/pip/pipenv/handler.go
+++ b/internal/modules/pip/pipenv/handler.go
@@ -103,8 +103,14 @@ func (m *pipenv) ListUsedModules(path string) ([]models.Module, error) {
 	if err := m.LoadModuleList(path); err != nil {
 		return m.allModules, errFailedToConvertModules
 	}
+
 	decoder := worker.NewMetadataDecoder(m.GetPackageDetails)
-	m.metainfo = decoder.ConvertMetadataToModules(m.pkgs, &m.allModules)
+	metainfo, err := decoder.ConvertMetadataToModules(m.pkgs, &m.allModules)
+	if err != nil {
+		return m.allModules, err
+	}
+
+	m.metainfo = metainfo
 	return m.allModules, nil
 }
 
@@ -138,8 +144,8 @@ func (m *pipenv) buildCmd(cmd command, path string) error {
 	return command.Build()
 }
 
-func (m *pipenv) GetPackageDetails(packageName string) (string, error) {
-	metatdataCmd := command(strings.ReplaceAll(string(MetadataCmd), placeholderPkgName, packageName))
+func (m *pipenv) GetPackageDetails(packageNameList string) (string, error) {
+	metatdataCmd := command(strings.ReplaceAll(string(MetadataCmd), placeholderPkgName, packageNameList))
 
 	m.buildCmd(metatdataCmd, m.basepath)
 	result, err := m.command.Output()

--- a/internal/modules/pip/poetry/handler.go
+++ b/internal/modules/pip/poetry/handler.go
@@ -103,8 +103,14 @@ func (m *poetry) ListUsedModules(path string) ([]models.Module, error) {
 	if err := m.LoadModuleList(path); err != nil {
 		return m.allModules, errFailedToConvertModules
 	}
+
 	decoder := worker.NewMetadataDecoder(m.GetPackageDetails)
-	m.metainfo = decoder.ConvertMetadataToModules(m.pkgs, &m.allModules)
+	metainfo, err := decoder.ConvertMetadataToModules(m.pkgs, &m.allModules)
+	if err != nil {
+		return m.allModules, err
+	}
+	m.metainfo = metainfo
+
 	return m.allModules, nil
 }
 

--- a/internal/modules/pip/pyenv/handler.go
+++ b/internal/modules/pip/pyenv/handler.go
@@ -122,8 +122,14 @@ func (m *pyenv) ListUsedModules(path string) ([]models.Module, error) {
 	if err := m.LoadModuleList(path); err != nil {
 		return m.allModules, errFailedToConvertModules
 	}
+
 	decoder := worker.NewMetadataDecoder(m.GetPackageDetails)
-	m.metainfo = decoder.ConvertMetadataToModules(m.pkgs, &m.allModules)
+	metainfo, err := decoder.ConvertMetadataToModules(m.pkgs, &m.allModules)
+	if err != nil {
+		return m.allModules, err
+	}
+	m.metainfo = metainfo
+
 	return m.allModules, nil
 }
 

--- a/internal/modules/pip/worker/worker.go
+++ b/internal/modules/pip/worker/worker.go
@@ -22,6 +22,7 @@ const VirtualEnv = "VIRTUAL_ENV"
 
 var errorWheelFileNotFound = fmt.Errorf("Wheel file not found")
 var errorUnableToOpenWheelFile = fmt.Errorf("Unable to open wheel file")
+var errorUnableToFetchPackageMetadata = fmt.Errorf("Unable to fetch package details")
 
 func IsRequirementMeet(data string) bool {
 	_modules := LoadModules(data)


### PR DESCRIPTION
The sbom generation code was optimized so that bom generation time is reduced as much as possible. 
The test data are as follows (all in seconds).
Speed Optimization - Ubuntu
     pipenv : 107.395164558  came down to 	15.507635382
     venv :    82.802944248  came down to 	15.193602392
	 
Speed Optimization - Windows
     pipenv :  	27.5308714  came down to 	25.9370292
	 poetry : 	27.0723658  came down to 	27.1199931
	 venv :     13.1809766  came down to	13.5110788