### PR TITLE
Python(Go) - pipenv/venv - Details of Document and root package are not matching with the repo against which SPDX file is generated issue fixed

### DIFF
--- a/internal/modules/pip/pipenv/handler.go
+++ b/internal/modules/pip/pipenv/handler.go
@@ -15,6 +15,8 @@ const cmdName = "pipenv"
 const manifestFile = "Pipfile"
 const manifestLockFile = "Pipfile.lock"
 const placeholderPkgName = "{PACKAGE}"
+const packageSrcLocation = "/src/"
+const packageSiteLocation = "/site-packages"
 
 var errDependenciesNotFound = errors.New("Unable to generate SPDX file: no modules or vendors found. Please install them before running spdx-sbom-generator, e.g.: `pipenv install` or `pipenv update`")
 var errBuildlingModuleDependencies = errors.New("Error building module dependencies")
@@ -37,7 +39,7 @@ func New() *pipenv {
 	return &pipenv{
 		metadata: models.PluginMetadata{
 			Name:       "The Python Package Index (PyPI)",
-			Slug:       "pip",
+			Slug:       "pipenv",
 			Manifest:   []string{manifestLockFile},
 			ModulePath: []string{},
 		},
@@ -169,7 +171,7 @@ func (m *pipenv) PushRootModuleToVenv() (bool, error) {
 
 func (m *pipenv) markRootModue() {
 	for i, pkg := range m.pkgs {
-		if pkg.Installer == "" {
+		if worker.IsRootModule(pkg, m.metadata.Slug) {
 			m.pkgs[i].Root = true
 			break
 		}

--- a/internal/modules/pip/poetry/handler.go
+++ b/internal/modules/pip/poetry/handler.go
@@ -37,7 +37,7 @@ func New() *poetry {
 	return &poetry{
 		metadata: models.PluginMetadata{
 			Name:       "The Python Package Index (PyPI)",
-			Slug:       "pip",
+			Slug:       "poetry",
 			Manifest:   []string{manifestLockFile},
 			ModulePath: []string{},
 		},
@@ -169,7 +169,7 @@ func (m *poetry) PushRootModuleToVenv() (bool, error) {
 
 func (m *poetry) markRootModue() {
 	for i, pkg := range m.pkgs {
-		if pkg.Installer == "poetry" {
+		if worker.IsRootModule(pkg, m.metadata.Slug) {
 			m.pkgs[i].Root = true
 			break
 		}

--- a/internal/modules/pip/pyenv/handler.go
+++ b/internal/modules/pip/pyenv/handler.go
@@ -4,7 +4,6 @@ package pyenv
 
 import (
 	"errors"
-	"path"
 	"path/filepath"
 	"runtime"
 	"spdx-sbom-generator/internal/helper"
@@ -45,7 +44,7 @@ func New() *pyenv {
 	return &pyenv{
 		metadata: models.PluginMetadata{
 			Name:       "The Python Package Index (PyPI)",
-			Slug:       "pip",
+			Slug:       "pyenv",
 			Manifest:   []string{manifestFile},
 			ModulePath: []string{},
 		},
@@ -198,9 +197,8 @@ func (m *pyenv) PushRootModuleToVenv() (bool, error) {
 }
 
 func (m *pyenv) markRootModue() {
-	nonRootModulePath := path.Join(m.basepath, m.venv)
 	for i, pkg := range m.pkgs {
-		if !strings.Contains(pkg.Location, nonRootModulePath) {
+		if worker.IsRootModule(pkg, m.metadata.Slug) {
 			m.pkgs[i].Root = true
 			break
 		}

--- a/internal/modules/pip/worker/worker.go
+++ b/internal/modules/pip/worker/worker.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"spdx-sbom-generator/internal/helper"
 	"strings"
 )
@@ -109,6 +110,30 @@ func IsValidRootModule(path string) bool {
 	modules := []string{manifestSetupCfg, manifestSetupPy}
 	for i := range modules {
 		if helper.Exists(filepath.Join(path, modules[i])) {
+			return true
+		}
+	}
+	return false
+}
+
+func IsRootModule(pkg Packages, pip_type string) bool {
+	osWin := "windows"
+	osDarwin := "darwin"
+	osLinux := "linux"
+	pipenv := "pipenv"
+	poetry := "poetry"
+	pyenv := "pyenv"
+	os := runtime.GOOS
+	if os == osWin && (pip_type == pipenv || pip_type == pyenv) {
+		if !strings.Contains(pkg.Location, "\\src\\") && !strings.Contains(pkg.Location, "\\site-packages") {
+			return true
+		}
+	} else if (os == osDarwin || os == osLinux) && (pip_type == pipenv || pip_type == pyenv) {
+		if !strings.Contains(pkg.Location, "/src/") && !strings.Contains(pkg.Location, "/site-packages") {
+			return true
+		}
+	} else if (os == osWin || os == osLinux || os == osDarwin) && pip_type == poetry {
+		if pkg.Installer == poetry {
 			return true
 		}
 	}


### PR DESCRIPTION
Python(Go) - pipenv/venv - Details of Document and root package are not matching with the repo against which SPDX file is generated issue fixed

Issue #156 fixed 