### PR TITLE
Set Go version to 1.15.14 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: "https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz"
+          goversion: "https://dl.google.com/go/go1.15.14.linux-amd64.tar.gz"
           project_path: "./cmd/generator"
           binary_name: "spdx-sbom-generator"
           ldflags: "-X 'main.version=${{ env.RELEASE_VERSION }}'"


### PR DESCRIPTION
The [latest run of the release workflow](https://github.com/spdx/spdx-sbom-generator/runs/3164808779) for v0.0.11 failed with "note: module requires Go 1.15".

This PR updates the release workflow to use the latest patch release of Go 1.15. I can't say for sure that the current source code is compatible with 1.15, but anecdotally, I've been developing locally on Go 1.16.3 and was able to run everything without a problem.